### PR TITLE
Best practices on the docker compse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env for local use.
+# Required: used by docker-compose.yml image/build args.
+IMAGE_TAG=dev
+
+# Optional local overrides
+API_PORT=8000
+APP_UID=1000
+APP_GID=1000
+
+# Optional Grafana admin credentials
+GF_ADMIN_USER=admin
+GF_ADMIN_PASSWORD=admin

--- a/Makefile
+++ b/Makefile
@@ -1,51 +1,60 @@
-.PHONY: build build-base build-api run-api-docker compose-up compose-up-debug compose-up-monitoring compose-down api-check repro repro-stage api-load lint lint-fix format clean-db prune-docker monitor-validate monitor-validate-compose monitor-validate-prometheus
+.PHONY: build build-base build-api run-api-docker compose-up compose-up-debug compose-up-monitoring compose-down api-check repro repro-stage api-load lint lint-fix format clean-db prune-docker monitor-validate monitor-validate-compose monitor-validate-prometheus check-image-tag
 
-IMAGE_TAG ?= latest
+ifneq (,$(wildcard .env))
+  include .env
+  export
+endif
+
+IMAGE_TAG ?=
 APP_UID ?= $(shell id -u)
 APP_GID ?= $(shell id -g)
 API_PORT ?= 8000
 PROMETHEUS_TOOL_IMAGE ?= prom/prometheus:v2.55.1
+COMPOSE := docker compose
+
+check-image-tag:
+	@test -n "$(IMAGE_TAG)" || (echo "IMAGE_TAG is required. Set it in .env (recommended) or pass IMAGE_TAG=<tag>." && exit 1)
 
 # ======================
 # Manual runs
 # ======================
-build: build-base
+build: check-image-tag build-base
 	docker build --build-arg BASE_IMAGE_TAG=$(IMAGE_TAG) -t load-forecast-ingestion:$(IMAGE_TAG) -f docker/ingestion/Dockerfile .
 	docker build --build-arg BASE_IMAGE_TAG=$(IMAGE_TAG) -t load-forecast-preprocessing:$(IMAGE_TAG) -f docker/preprocessing/Dockerfile .
 	docker build --build-arg BASE_IMAGE_TAG=$(IMAGE_TAG) -t load-forecast-marts:$(IMAGE_TAG) -f docker/marts/Dockerfile .
 	docker build --build-arg BASE_IMAGE_TAG=$(IMAGE_TAG) -t load-forecast-api:$(IMAGE_TAG) -f docker/api/Dockerfile .
 
-build-api: build-base
+build-api: check-image-tag build-base
 	docker build --build-arg BASE_IMAGE_TAG=$(IMAGE_TAG) -t load-forecast-api:$(IMAGE_TAG) -f docker/api/Dockerfile .
 
-build-base:
+build-base: check-image-tag
 	docker build --build-arg APP_UID=$(APP_UID) --build-arg APP_GID=$(APP_GID) -t load-forecast-base:$(IMAGE_TAG) -f docker/base/Dockerfile .
 
-repro: build
+repro: check-image-tag build
 	IMAGE_TAG=$(IMAGE_TAG) dvc repro
 
-repro-stage: build
+repro-stage: check-image-tag build
 	@test -n "$(STAGE)" || (echo "Usage: make repro-stage STAGE=<stage-name> [IMAGE_TAG=<tag>]" && exit 1)
 	IMAGE_TAG=$(IMAGE_TAG) dvc repro $(STAGE)
 
-run-api-docker: build-api
+run-api-docker: check-image-tag build-api
 	docker run --rm --pull=never -p $(API_PORT):8000 --mount type=bind,src=$(CURDIR)/data,dst=/app/data,readonly load-forecast-api:$(IMAGE_TAG)
 
-compose-up:
-	docker compose build base
-	docker compose build
-	API_PORT=$(API_PORT) docker compose up
+compose-up: check-image-tag
+	$(COMPOSE) build base
+	$(COMPOSE) build
+	API_PORT=$(API_PORT) $(COMPOSE) up
 
-compose-up-debug:
-	docker compose -f docker-compose.yml -f docker-compose.debug.yml build base
-	docker compose -f docker-compose.yml -f docker-compose.debug.yml build
-	API_PORT=$(API_PORT) docker compose -f docker-compose.yml -f docker-compose.debug.yml up
+compose-up-debug: check-image-tag
+	$(COMPOSE) -f docker-compose.yml -f docker-compose.debug.yml build base
+	$(COMPOSE) -f docker-compose.yml -f docker-compose.debug.yml build
+	API_PORT=$(API_PORT) $(COMPOSE) -f docker-compose.yml -f docker-compose.debug.yml up
 
-compose-up-monitoring:
-	API_PORT=$(API_PORT) docker compose up -d --build prometheus alertmanager node-exporter cadvisor api
+compose-up-monitoring: check-image-tag
+	API_PORT=$(API_PORT) $(COMPOSE) up -d --build prometheus alertmanager node-exporter cadvisor api
 
 compose-down:
-	docker compose down --remove-orphans
+	$(COMPOSE) down --remove-orphans
 
 api-check:
 	@echo "Checking API health on localhost:$(API_PORT)"
@@ -109,7 +118,7 @@ monitor-validate: monitor-validate-compose monitor-validate-prometheus
 
 monitor-validate-compose:
 	@echo "Validating docker-compose.yml"
-	docker compose config > /tmp/compose.rendered.yml
+	$(COMPOSE) config > /tmp/compose.rendered.yml
 
 monitor-validate-prometheus:
 	@echo "Validating Prometheus config and rule files"

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -2,6 +2,10 @@
 # Optional local debug overrides: publish selected monitoring ports on localhost only.
 
 services:
+  api:
+    ports:
+      - "127.0.0.1:${API_PORT:-8000}:8000"
+
   prometheus:
     ports:
       - "127.0.0.1:9090:9090"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,14 @@ services:
       - "--storage.tsdb.retention.time=15d"
       - "--web.external-url=http://localhost:8080/prometheus/"
       - "--web.route-prefix=/"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
+    networks:
+      - backend
     restart: unless-stopped
 
   # Prometheus: System Metrics
@@ -40,6 +48,8 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
+    networks:
+      - backend
     restart: unless-stopped
 
   # Prometheus: Docker container metrics
@@ -58,6 +68,8 @@ services:
       - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker:/var/lib/docker:ro
+    networks:
+      - backend
     restart: unless-stopped
 
   # Prometheus: Alerts
@@ -75,6 +87,14 @@ services:
       - "--storage.path=/alertmanager"
       - "--web.external-url=http://localhost:8080/alerts/"
       - "--web.route-prefix=/"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9093/-/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
+    networks:
+      - backend
     restart: unless-stopped
 
   # Grafana
@@ -82,7 +102,8 @@ services:
     image: grafana/grafana:12.3.0
     container_name: load-forecast-grafana
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
     environment:
       - GF_SERVER_ROOT_URL=http://localhost:8080/grafana/
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
@@ -94,6 +115,14 @@ services:
       - ./deployment/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./deployment/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ./deployment/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
+    networks:
+      - backend
     restart: unless-stopped
 
 
@@ -104,17 +133,18 @@ services:
   nginx:
     image: nginx:1.27
     container_name: load-forecast-nginx
-    depends_on:
-      - api
-      - prometheus
-      - cadvisor
-      - alertmanager
-      - node-exporter
-      - grafana
     ports:
     - "8080:80"
     volumes:
       - ./deployment/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - backend
     restart: unless-stopped
 
   # ------------------------------------
@@ -129,24 +159,32 @@ services:
         - APP_UID=${APP_UID:-1000}
         - APP_GID=${APP_GID:-1000}
     image:
-      load-forecast-base:${IMAGE_TAG:-latest}
+      load-forecast-base:${IMAGE_TAG:?IMAGE_TAG is required}
+    networks:
+      - backend
 
   api:
     build:
       context: .
       dockerfile: docker/api/Dockerfile
       args:
-        BASE_IMAGE_TAG: ${IMAGE_TAG:-latest}
+        BASE_IMAGE_TAG: ${IMAGE_TAG:?IMAGE_TAG is required}
     image:
-      load-forecast-api:${IMAGE_TAG:-latest}
+      load-forecast-api:${IMAGE_TAG:?IMAGE_TAG is required}
     depends_on:
       base:
         condition: service_completed_successfully
-    ports:
-      - "${API_PORT:-8000}:8000"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 20s
+    networks:
+      - backend
     restart: unless-stopped
 
   ingestion:
@@ -154,45 +192,54 @@ services:
       context: .
       dockerfile: docker/ingestion/Dockerfile
       args:
-        BASE_IMAGE_TAG: ${IMAGE_TAG:-latest}
+        BASE_IMAGE_TAG: ${IMAGE_TAG:?IMAGE_TAG is required}
     image:
-      load-forecast-ingestion:${IMAGE_TAG:-latest}
+      load-forecast-ingestion:${IMAGE_TAG:?IMAGE_TAG is required}
     depends_on:
       base:
         condition: service_completed_successfully
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
+    networks:
+      - backend
 
   preprocessing:
     build:
       context: .
       dockerfile: docker/preprocessing/Dockerfile
       args:
-        BASE_IMAGE_TAG: ${IMAGE_TAG:-latest}  
+        BASE_IMAGE_TAG: ${IMAGE_TAG:?IMAGE_TAG is required}
     image:
-      load-forecast-preprocessing:${IMAGE_TAG:-latest}
+      load-forecast-preprocessing:${IMAGE_TAG:?IMAGE_TAG is required}
     depends_on:
       ingestion:
         condition: service_completed_successfully
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
+    networks:
+      - backend
 
   marts:
     build:
       context: .
       dockerfile: docker/marts/Dockerfile
       args:
-        - BASE_IMAGE_TAG=${IMAGE_TAG:-latest}
+        - BASE_IMAGE_TAG=${IMAGE_TAG:?IMAGE_TAG is required}
     image:
-      load-forecast-marts:${IMAGE_TAG:-latest}
+      load-forecast-marts:${IMAGE_TAG:?IMAGE_TAG is required}
     depends_on:
       preprocessing:
         condition: service_completed_successfully
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
+    networks:
+      - backend
+
+networks:
+  backend:
 
 volumes:
   prometheus_data:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,6 +1,6 @@
 # docker/api/Dockerfile
 
-ARG BASE_IMAGE_TAG=latest
+ARG BASE_IMAGE_TAG=unset
 FROM load-forecast-base:${BASE_IMAGE_TAG}
 
 WORKDIR /app

--- a/docker/ingestion/Dockerfile
+++ b/docker/ingestion/Dockerfile
@@ -1,6 +1,6 @@
 # docker/ingestion/Dockerfile
 
-ARG BASE_IMAGE_TAG=latest
+ARG BASE_IMAGE_TAG=unset
 FROM load-forecast-base:${BASE_IMAGE_TAG}
 
 WORKDIR /app

--- a/docker/marts/Dockerfile
+++ b/docker/marts/Dockerfile
@@ -1,6 +1,6 @@
 # docker/marts/Dockerfile
 
-ARG BASE_IMAGE_TAG=latest
+ARG BASE_IMAGE_TAG=unset
 FROM load-forecast-base:${BASE_IMAGE_TAG}
 
 WORKDIR /app

--- a/docker/preprocessing/Dockerfile
+++ b/docker/preprocessing/Dockerfile
@@ -1,6 +1,6 @@
 # docker/preprocessing/Dockerfile
 
-ARG BASE_IMAGE_TAG=latest
+ARG BASE_IMAGE_TAG=unset
 FROM load-forecast-base:${BASE_IMAGE_TAG}
 
 WORKDIR /app


### PR DESCRIPTION
- Added explicit backend network and attached all services to it:
  - docker-compose.yml
  - docker-compose.yml

- Added healthchecks for long-running core services:
  - Prometheus: docker-compose.yml
  - Alertmanager: docker-compose.yml
  - Grafana: docker-compose.yml
  - API: docker-compose.yml
  - Nginx: docker-compose.yml

- Switched Grafana dependency to readiness-based startup:
  - Prometheus must be healthy before Grafana starts: docker-compose.yml

- Removed broad Nginx startup coupling:
  - Removed Nginx depends_on block and kept it independent: docker-compose.yml

- Enforced single entrypoint in base Compose:
  - Removed direct API port publish from base file: docker-compose.yml
  - Added API direct port only in debug override: docker-compose.debug.yml

- Removed latest-tag fallbacks in Compose image tags/build args:
  - Base/API/ingestion/preprocessing/marts now require IMAGE_TAG: docker-compose.yml, docker-compose.yml, docker-compose.yml, docker-compose.yml, docker-compose.yml

- Removed latest default in service Dockerfiles for base-image ARG:
  - Dockerfile
  - Dockerfile
  - Dockerfile
  - Dockerfile

Validation

- Compose merge/render passes:
  - Ran with IMAGE_TAG set: docker compose -f docker-compose.yml -f docker-compose.debug.yml config
  - Result: Compose config OK

- Editor diagnostics:
  - No remaining errors in modified files.
