### PR TITLE
KAN-22: issue49

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,10 @@ MLFLOW_PORT=5001
 DAGSHUB_REPO=
 MLFLOW_TRACKING_USERNAME=
 MLFLOW_TRACKING_PASSWORD=
+
+# Airlfow parameters
+AIRFLOW__CORE__PARALLELISM=4  # Defaults value is 4
+AIRFLOW__CORE__DAG_CONCURRENCY=4  # Defaults value is 4
+AIRFLOW__CORE__MAX_ACTIVE_TASKS_PER_DAG=4  # Defaults value is 4
+
+AIRFLOW__API_AUTH__JWT_SECRET=-use-jwt-secret-to-a-long-random-value-64-chars-min

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ x-airflow-common: &airflow-common
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__CORE__LOAD_EXAMPLES: "False"
     AIRFLOW__CORE__DEFAULT_TIMEZONE: Europe/Berlin
+    AIRFLOW__CORE__EXECUTION_API_SERVER_URL: http://airflow-api:8080/airflow/execution/
+    AIRFLOW__API_AUTH__JWT_SECRET: "${AIRFLOW__API_AUTH__JWT_SECRET}"
+    _PIP_ADDITIONAL_REQUIREMENTS: "${AIRFLOW_PIP_ADDITIONAL_REQUIREMENTS:-duckdb>=1.5.0}"
+    AIRFLOW__CORE__PARALLELISM: ${AIRFLOW__CORE__PARALLELISM:-4}
+    AIRFLOW__CORE__DAG_CONCURRENCY: ${AIRFLOW__CORE__DAG_CONCURRENCY:-4}
+    AIRFLOW__CORE__MAX_ACTIVE_TASKS_PER_DAG: ${AIRFLOW__CORE__MAX_ACTIVE_TASKS_PER_DAG:-4}
     AIRFLOW__CORE__AUTH_MANAGER: airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://${AIRFLOW_DB_USER:-airflow}:${AIRFLOW_DB_PASSWORD:-airflow}@airflow-postgres/${AIRFLOW_DB_NAME:-airflow}"
     TZ: Europe/Berlin
@@ -338,6 +344,8 @@ services:
         condition: service_completed_successfully
       airflow-dag-processor:
         condition: service_healthy
+      airflow-api:
+        condition: service_started
     environment:
       <<: *airflow-common-env
       AIRFLOW_VAR_MLFLOW_TRACKING_URI: "${MLFLOW_TRACKING_URI:-http://mlflow:5000}"


### PR DESCRIPTION
changed

Fixed execution API endpoint path in docker-compose.yml:11 to:
http://airflow-api:8080/airflow/execution/
Added shared JWT signing secret in docker-compose.yml:12 so scheduler and api-server validate the same execution tokens.
Ensured scheduler startup order includes api-server in docker-compose.yml:347.
Added duckdb runtime dependency for Airflow task processes in docker-compose.yml:13, since ingestion was then failing with ModuleNotFoundError after API issues were solved.