### PR TITLE
update the deprecated import

### DIFF
--- a/airflow/dags/operators.py
+++ b/airflow/dags/operators.py
@@ -4,7 +4,7 @@ Set Operators for the pipelines
 
 import os
 
-from airflow.operators.bash import BashOperator
+from airflow.providers.standard.operators.bash import BashOperator
 
 
 class BasePythonOperator(BashOperator):


### PR DESCRIPTION
Updated the deprecated import path in operators.py:7
Replaced old namespace with Airflow 3 provider namespace for BashOperator