### PR TITLE
KAN-26: add fix for an error and update a depracted git version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ permissions:
   contents: read
   deployments: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 
 jobs:
   deploy-staging:
@@ -32,7 +35,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create Deployment (Staging)
         id: create_deployment
@@ -45,11 +48,17 @@ jobs:
         run: echo "Deploying to staging..."
 
       - name: Notify Discord
-        if: always()
+        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+          curl --fail-with-body -sS -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{ \"content\": \"Staging deploy: ${{ job.status }}\" }"
+
+      - name: Discord webhook not configured
+        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL == '' }}
+        run: echo "Skipping Discord notification because DISCORD_WEBHOOK_URL is not set."
 
   deploy-production:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
@@ -59,7 +68,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create Deployment (Production)
         id: create_deployment
@@ -72,8 +81,14 @@ jobs:
         run: echo "Deploying to production..."
 
       - name: Notify Discord
-        if: always()
+        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL != '' }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
-          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+          curl --fail-with-body -sS -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{ \"content\": \"Production deploy: ${{ job.status }}\" }"
+
+      - name: Discord webhook not configured
+        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL == '' }}
+        run: echo "Skipping Discord notification because DISCORD_WEBHOOK_URL is not set."


### PR DESCRIPTION
Prevented Discord step from failing when secret is missing:
Notify Discord now runs only if secrets.DISCORD_WEBHOOK_URL is set in both jobs: deploy.yml:50 and deploy.yml:83
Added a fallback step that logs a skip message when the secret is not configured: deploy.yml:59 and deploy.yml:92
Switched curl to --fail-with-body -sS for clearer failures: deploy.yml:55 and deploy.yml:88
Addressed Node.js 20 deprecation warning:
Updated actions/checkout from v4 to v5: deploy.yml:38 and deploy.yml:71
Added workflow-level opt-in to Node 24 now:
FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true" at deploy.yml:26
