### PR TITLE
KAN-27: issue59

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ on:
     inputs:
       environment:
         description: "Environment to deploy"
+        type: choice
+        options:
+          - staging
+          - production
         required: true
         default: staging
 
@@ -28,10 +32,11 @@ env:
 
 jobs:
   deploy-staging:
-    if: github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
     runs-on: ubuntu-latest
+    environment: staging
     concurrency:
-      group: staging-deploy
+      group: staging-deploy-${{ github.ref_name }}
       cancel-in-progress: true
     steps:
       - name: Checkout code
@@ -48,21 +53,23 @@ jobs:
         run: echo "Deploying to staging..."
 
       - name: Notify Discord
-        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL != '' }}
+        if: always()
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "Skipping Discord notification because DISCORD_WEBHOOK_URL is not set."
+            exit 0
+          fi
+
           curl --fail-with-body -sS -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{ \"content\": \"Staging deploy: ${{ job.status }}\" }"
 
-      - name: Discord webhook not configured
-        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL == '' }}
-        run: echo "Skipping Discord notification because DISCORD_WEBHOOK_URL is not set."
-
   deploy-production:
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
+    environment: production
     concurrency:
       group: production-deploy
       cancel-in-progress: false
@@ -81,14 +88,15 @@ jobs:
         run: echo "Deploying to production..."
 
       - name: Notify Discord
-        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL != '' }}
+        if: always()
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "Skipping Discord notification because DISCORD_WEBHOOK_URL is not set."
+            exit 0
+          fi
+
           curl --fail-with-body -sS -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{ \"content\": \"Production deploy: ${{ job.status }}\" }"
-
-      - name: Discord webhook not configured
-        if: ${{ always() && secrets.DISCORD_WEBHOOK_URL == '' }}
-        run: echo "Skipping Discord notification because DISCORD_WEBHOOK_URL is not set."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@
 #   Add manual or tag-based trigger for production deploy.
 #   Use secrets for credentials.
 #   Notify team on deploy
+
 name: Deploy
 
 on:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,9 +62,17 @@ jobs:
             exit 0
           fi
 
-          curl --fail-with-body -sS -X POST "$DISCORD_WEBHOOK_URL" \
+          http_code=$(curl -sS -o /tmp/discord_response.txt -w "%{http_code}" -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{ \"content\": \"Staging deploy: ${{ job.status }}\" }"
+            -d "{ \"content\": \"Staging deploy: ${{ job.status }}\" }")
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            echo "Discord webhook accepted (HTTP $http_code)."
+          else
+            echo "Discord webhook failed (HTTP $http_code). Response body:" >&2
+            cat /tmp/discord_response.txt >&2
+            exit 1
+          fi
 
   deploy-production:
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production' && github.ref == 'refs/heads/main')
@@ -97,6 +105,14 @@ jobs:
             exit 0
           fi
 
-          curl --fail-with-body -sS -X POST "$DISCORD_WEBHOOK_URL" \
+          http_code=$(curl -sS -o /tmp/discord_response.txt -w "%{http_code}" -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{ \"content\": \"Production deploy: ${{ job.status }}\" }"
+            -d "{ \"content\": \"Production deploy: ${{ job.status }}\" }")
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            echo "Discord webhook accepted (HTTP $http_code)."
+          else
+            echo "Discord webhook failed (HTTP $http_code). Response body:" >&2
+            cat /tmp/discord_response.txt >&2
+            exit 1
+          fi


### PR DESCRIPTION
Updated both notify steps in deploy.yml:50 and deploy.yml:93 to capture HTTP status from Discord.
Added explicit success log line:
Discord webhook accepted (HTTP <status>).
Added explicit failure handling with response body output and exit 1 for non-2xx responses.