### PR TITLE
Update RBAC roles to use "viewer" instead of "user"

### DIFF
--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -22,7 +22,7 @@ Built with these layers:
 
 4. **RBAC (Role-Based Access Control)**  
    - `GET /auth/admin-only` — only `admin` role allowed  
-   - `GET /auth/user-only` — only `user` role allowed  
+   - `GET /auth/user-only` — only `viewer` role allowed  
    - Enforced via a reusable `require_role()` dependency factory
 
 ### Architecture Decisions
@@ -38,7 +38,7 @@ Built with these layers:
 ### The idea behind it
 It's a **lightweight auth sidecar** for the ML pipeline — not a full identity provider.
 It gives other services (Airflow DAGs, model-serving APIs, etc.) a simple way to gate endpoints
-behind JWT-authenticated roles (`admin` vs `user`), using a local DuckDB file instead of a full
+behind JWT-authenticated roles (`admin`, `engineer`, `ops`, `viewer`), using a local DuckDB file instead of a full
 PostgreSQL/Redis stack. Keeps infrastructure minimal while still supporting RBAC.
 """
 

--- a/services/auth/app/models.py
+++ b/services/auth/app/models.py
@@ -11,7 +11,7 @@ class User(BaseModel):
         id: Auto-assigned integer primary key from DuckDB. None before insertion.
         username: Unique login name for the user.
         password_hashed: Argon2 hash of the user's password — never store plain text.
-        role: Access role (e.g. ``"admin"`` or ``"user"``) used for RBAC checks.
+        role: Access role — one of ``"admin"``, ``"engineer"``, ``"ops"``, or ``"viewer"`` — used for RBAC checks.
     """
 
     id: int | None = None

--- a/services/auth/routes/register.py
+++ b/services/auth/routes/register.py
@@ -26,7 +26,7 @@ class RegisterRequest(BaseModel):
 
     username: str
     password: str
-    role: str = "user"
+    role: str = "viewer"
 
 
 @router.post("/register")

--- a/services/auth/routes/test_rbac.py
+++ b/services/auth/routes/test_rbac.py
@@ -30,8 +30,8 @@ def admin_only_route(user=Depends(require_role("admin"))):
 
 
 @router.get("/user-only")
-def user_only_route(user=Depends(require_role("user"))):
-    """Endpoint accessible only to users with the ``"user"`` role.
+def user_only_route(user=Depends(require_role("viewer"))):
+    """Endpoint accessible only to users with the ``"viewer"`` role.
 
     Args:
         user: Decoded JWT payload, injected and role-checked by ``require_role``.
@@ -40,7 +40,7 @@ def user_only_route(user=Depends(require_role("user"))):
         A welcome message and the user payload.
 
     Raises:
-        HTTPException: 403 if the caller's role is not ``"user"``.
+        HTTPException: 403 if the caller's role is not ``"viewer"``.
     """
     return {"message": "Welcome user", "user": user}
 


### PR DESCRIPTION
Replace instances of the "user" role with "viewer" across authentication routes and models to enhance clarity and consistency in role-based access control. This change ensures that the system accurately reflects the intended access levels.